### PR TITLE
Trailing Spaces Fix

### DIFF
--- a/NginxConfigParser/Token.cs
+++ b/NginxConfigParser/Token.cs
@@ -45,7 +45,7 @@ namespace NginxConfigParser
         public GroupToken(GroupToken parent, string key, string value = null, string comment = null)
         {
             Key = key;
-            Value = value;
+            Value = value == null ? value : value.Trim();
             Comment = comment;
             Tokens = new List<IToken>();
             Parent = parent;


### PR DESCRIPTION
When using the library to save a nginx configuration file, there is always a extra space added on after a group value and eventually the library throws an error when reading the configuration file. This fixes that issue by removing spaces at the start and end of a group value.