### PR TITLE
Multi-target net9/net10, serialization fixes, and unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,13 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore dependencies
       run: dotnet restore
 
     - name: Build
       run: dotnet build --no-restore -c Release
+
+    - name: Test
+      run: dotnet test --no-build -c Release --verbosity normal

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Install Dotnet Tool
       run: |

--- a/NginxConfigParser.sln
+++ b/NginxConfigParser.sln
@@ -13,20 +13,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NginxConfigParserUnitTests", "NginxConfigParserUnitTests\NginxConfigParserUnitTests.csproj", "{A16D4B71-0B10-4355-8445-22A47A7DA945}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Debug|x64.Build.0 = Debug|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Debug|x86.Build.0 = Debug|Any CPU
 		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Release|x64.ActiveCfg = Release|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Release|x64.Build.0 = Release|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Release|x86.ActiveCfg = Release|Any CPU
+		{ED1C5B3D-DE74-4A13-9147-D549A9F5B38E}.Release|x86.Build.0 = Release|Any CPU
 		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Debug|x86.Build.0 = Debug|Any CPU
 		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Release|x64.Build.0 = Release|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Release|x86.ActiveCfg = Release|Any CPU
+		{2BBCF05E-1BE5-47E7-A314-1C7D6591704D}.Release|x86.Build.0 = Release|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Debug|x64.Build.0 = Debug|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Debug|x86.Build.0 = Debug|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Release|x64.ActiveCfg = Release|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Release|x64.Build.0 = Release|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Release|x86.ActiveCfg = Release|Any CPU
+		{A16D4B71-0B10-4355-8445-22A47A7DA945}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NginxConfigParser/NginxConfig.cs
+++ b/NginxConfigParser/NginxConfig.cs
@@ -8,7 +8,8 @@ using System.Text.RegularExpressions;
 namespace NginxConfigParser;
 
 /// <summary>
-///  Represents an nginx configuration file operation object.
+/// Reads, builds, and writes nginx configuration files.
+/// Key paths use colon-separated segments with optional indexes, e.g. <c>http:server[1]:root</c>.
 /// </summary>
 public class NginxConfig
 {
@@ -19,6 +20,9 @@ public class NginxConfig
 
     private IList<IToken> _tokens = new List<IToken>();
 
+    /// <summary>
+    /// Initializes a new instance from an existing parser.
+    /// </summary>
     protected NginxConfig(Parser parser)
     {
         _parser = parser;
@@ -27,7 +31,7 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Create an new
+    /// Creates an empty configuration.
     /// </summary>
     public static NginxConfig Create()
     {
@@ -37,12 +41,12 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Load from specific file
+    /// Loads configuration from a file path.
     /// </summary>
-    /// <param name="fileName">The file path</param>
-    /// <returns><see cref="NginxConfig"/></returns>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="FileNotFoundException"></exception>
+    /// <param name="fileName">Path to the nginx config file.</param>
+    /// <returns>The loaded configuration.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fileName"/> is null or whitespace.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
     public static NginxConfig LoadFrom(string fileName)
     {
         if (string.IsNullOrWhiteSpace(fileName))
@@ -61,11 +65,11 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Load from file content
+    /// Loads configuration from text content.
     /// </summary>
-    /// <param name="content">The string of file content</param>
-    /// <returns><see cref="NginxConfig"/></returns>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <param name="content">Nginx config text.</param>
+    /// <returns>The loaded configuration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="content"/> is null.</exception>
     public static NginxConfig Load(string content)
     {
         if (content is null)
@@ -85,15 +89,15 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Get all values
+    /// Returns all root-level tokens.
     /// </summary>
     public IEnumerable<IToken> GetTokens() => _tokens;
 
     /// <summary>
-    ///  Read value from given the key path.
-    ///  if the key not exist, will return null.
+    /// Gets a single token by key path, or null if not found.
     /// </summary>
-    /// <exception cref="ArgumentException"></exception>
+    /// <param name="keyPath">Colon-separated key path, e.g. <c>http:server:listen</c>.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="keyPath"/> is null or whitespace.</exception>
     public IValueToken GetToken(string keyPath)
     {
         if (string.IsNullOrWhiteSpace(keyPath))
@@ -105,9 +109,11 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Read value list from given the key path.
+    /// Gets all tokens matching the key path (for repeated directives).
     /// </summary>
-    /// <exception cref="ArgumentException"></exception>
+    /// <param name="keyPath">Colon-separated key path, e.g. <c>http:include</c>.</param>
+    /// <returns>Matching tokens, or an empty list when none are found.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="keyPath"/> is null or whitespace.</exception>
     public IList<IValueToken> GetTokens(string keyPath)
     {
         if (string.IsNullOrWhiteSpace(keyPath))
@@ -119,9 +125,10 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Read all values from specific group key
+    /// Gets a root-level group block by name, or null if not found.
     /// </summary>
-    /// <exception cref="ArgumentException"></exception>
+    /// <param name="key">Group name, e.g. <c>http</c> or <c>events</c>.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> is null or whitespace.</exception>
     public GroupToken GetGroup(string key)
     {
         if (string.IsNullOrWhiteSpace(key))
@@ -135,10 +142,10 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Read value from given the key path.
-    ///  if the key not exist, will return null.
+    /// Gets a token by key path, or null if not found.
     /// </summary>
-    /// <exception cref="ArgumentException"></exception>
+    /// <param name="keyPath">Colon-separated key path, e.g. <c>http:server[1]:root</c>.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="keyPath"/> is null or whitespace.</exception>
     public IValueToken this[string keyPath]
     {
         get
@@ -153,14 +160,15 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Add or update value by the key path
+    /// Adds or updates a value at the key path. Creates missing parent groups as needed.
     /// </summary>
-    /// <param name="keyPath">The key path</param>
-    /// <param name="value">The string value</param>
-    /// <param name="addAsGroup">Add as group when key path not found</param>
-    /// <param name="comment">The comment</param>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="IndexOutOfRangeException"></exception>
+    /// <param name="keyPath">Colon-separated key path.</param>
+    /// <param name="value">Directive value.</param>
+    /// <param name="addAsGroup">When true, creates a group block instead of a simple value.</param>
+    /// <param name="comment">Optional inline comment.</param>
+    /// <returns>This instance for chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="keyPath"/> is null or whitespace.</exception>
+    /// <exception cref="IndexOutOfRangeException">Thrown when a path index is out of range.</exception>
     public NginxConfig AddOrUpdate(string keyPath, string value, bool addAsGroup = false, string comment = null)
     {
         if (string.IsNullOrWhiteSpace(keyPath))
@@ -246,10 +254,12 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Remove the value by key path
+    /// Removes tokens at the key path. With an index, removes one item; without, removes all matches.
     /// </summary>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="IndexOutOfRangeException"></exception>
+    /// <param name="keyPath">Colon-separated key path, e.g. <c>http:include[1]</c>.</param>
+    /// <returns>This instance for chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="keyPath"/> is null or whitespace.</exception>
+    /// <exception cref="IndexOutOfRangeException">Thrown when a path index is out of range.</exception>
     public NginxConfig Remove(string keyPath)
     {
         if (string.IsNullOrWhiteSpace(keyPath))
@@ -322,10 +332,10 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Save the configuration content to specific file
+    /// Saves the configuration to a file using UTF-8 without BOM.
     /// </summary>
-    /// <param name="fileName">The file path</param>
-    /// <exception cref="ArgumentException"></exception>
+    /// <param name="fileName">Output file path.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fileName"/> is null or whitespace.</exception>
     public void Save(string fileName)
     {
         if (string.IsNullOrWhiteSpace(fileName))
@@ -337,12 +347,12 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Save the configuration content to specific file
+    /// Saves the configuration to a file with the given encoding.
     /// </summary>
-    /// <param name="fileName">The file path</param>
-    /// <param name="encoding">The file encoding</param>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="ArgumentNullException"></exception>
+    /// <param name="fileName">Output file path.</param>
+    /// <param name="encoding">Text encoding to use.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="fileName"/> is null or whitespace.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="encoding"/> is null.</exception>
     public void Save(string fileName, Encoding encoding)
     {
         if (string.IsNullOrWhiteSpace(fileName))
@@ -366,7 +376,7 @@ public class NginxConfig
     }
 
     /// <summary>
-    ///  Return configuration file content
+    /// Returns the configuration as nginx config text.
     /// </summary>
     public override string ToString()
     {

--- a/NginxConfigParser/NginxConfig.cs
+++ b/NginxConfigParser/NginxConfig.cs
@@ -13,6 +13,7 @@ namespace NginxConfigParser;
 public class NginxConfig
 {
     private static readonly Regex KeyRegex = new(@"^[\w]+(\[\d+\])?$");
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
     private readonly Parser _parser;
 
@@ -53,8 +54,6 @@ public class NginxConfig
         {
             throw new FileNotFoundException(fileName);
         }
-
-        // var fs = new FileStream(fileName, FileMode.Open, FileAccess.ReadWrite);
 
         var content = File.ReadAllText(fileName);
 
@@ -179,7 +178,7 @@ public class NginxConfig
 
         for (int i = 0; i < length; i++)
         {
-            var (key, index) = ResolveKey(paths[i]);
+            var (key, index, _) = ResolveKey(paths[i]);
 
             IToken find = null;
             IEnumerable<IToken> findTokens;
@@ -268,7 +267,7 @@ public class NginxConfig
 
         for (int i = 0; i < length; i++)
         {
-            var (key, index) = ResolveKey(paths[i]);
+            var (key, index, hasIndex) = ResolveKey(paths[i]);
 
             IToken find = null;
             IEnumerable<IToken> findTokens;
@@ -280,19 +279,21 @@ public class NginxConfig
 
             if (i == length - 1)
             {
-                // remove
-                if (groupToken == null)
+                IList<IToken> targetList = groupToken == null ? tokens : groupToken.Tokens;
+
+                if (hasIndex)
                 {
-                    foreach (var item in findTokens)
-                    {
-                        tokens.Remove(item);
-                    }
+                    var findTokensCount = findTokens.Count();
+                    if (index < 0 || index >= findTokensCount)
+                        throw new IndexOutOfRangeException($"The key '{key}' index must be >= 0 and < {findTokensCount}");
+
+                    targetList.Remove(findTokens.ElementAt(index));
                 }
                 else
                 {
                     foreach (var item in findTokens)
                     {
-                        groupToken.Tokens.Remove(item);
+                        targetList.Remove(item);
                     }
                 }
             }
@@ -332,7 +333,7 @@ public class NginxConfig
             throw new ArgumentException($"'{nameof(fileName)}' cannot be null or whitespace.", nameof(fileName));
         }
 
-        Save(fileName, Encoding.Default);
+        Save(fileName, Utf8NoBom);
     }
 
     /// <summary>
@@ -378,33 +379,38 @@ public class NginxConfig
 
     private void WriteTokenString(IEnumerable<IToken> tokens, TextWriter textWriter, int level = 0)
     {
-        var normalTokens = tokens.Where(x => x is CommentToken || x is ValueToken);
-        var groupTokens = tokens.Where(x => x is GroupToken);
-
         textWriter.NewLine = Environment.NewLine;
 
-        foreach (var token in normalTokens)
+        var tokenList = tokens as IList<IToken> ?? tokens.ToList();
+        var wroteAny = false;
+
+        foreach (var token in tokenList)
         {
             if (token is CommentToken comment)
+            {
                 textWriter.WriteLine(PadLeftSpace(comment.ToString(), level));
-            else if (token is ValueToken vaue)
-                textWriter.WriteLine(PadLeftSpace(vaue.ToString(), level));
-        }
+                wroteAny = true;
+            }
+            else if (token is ValueToken value)
+            {
+                textWriter.WriteLine(PadLeftSpace(value.ToString(), level));
+                wroteAny = true;
+            }
+            else if (token is GroupToken group)
+            {
+                if (wroteAny)
+                    textWriter.WriteLine();
 
-        foreach (GroupToken group in groupTokens)
-        {
-            //if (group.Parent != null)
-            textWriter.WriteLine();
+                if (!string.IsNullOrWhiteSpace(group.Comment))
+                    textWriter.WriteLine(PadLeftSpace($"{group.Key}  {group.Value} {{ # {group.Comment}", level));
+                else
+                    textWriter.WriteLine(PadLeftSpace($"{group.Key}  {group.Value} {{ ", level));
 
-            if (!string.IsNullOrWhiteSpace(group.Comment))
-                textWriter.WriteLine(PadLeftSpace($"{group.Key}  {group.Value} {{ # {group.Comment}", level));
-            else
-                textWriter.WriteLine(PadLeftSpace($"{group.Key}  {group.Value} {{ ", level));
+                WriteTokenString(group.Tokens, textWriter, level + 1);
 
-            WriteTokenString(group.Tokens, textWriter, level + 1);
-
-            // end 
-            textWriter.WriteLine(PadLeftSpace("}", level));
+                textWriter.WriteLine(PadLeftSpace("}", level));
+                wroteAny = true;
+            }
         }
     }
 
@@ -423,7 +429,7 @@ public class NginxConfig
 
         foreach (var key in paths)
         {
-            var (keyName, index) = ResolveKey(key);
+            var (keyName, index, _) = ResolveKey(key);
 
             result = FindToken(tokens, keyName, index);
             if (result != null)
@@ -446,13 +452,13 @@ public class NginxConfig
 
         var paths = keyPath.Split(':');
 
-        IEnumerable<IValueToken> result = null;
+        IEnumerable<IValueToken> result = Array.Empty<IValueToken>();
 
         IValueToken current = null;
 
         for (int i = 0; i < paths.Length; i++)
         {
-            var (keyName, index) = ResolveKey(paths[i]);
+            var (keyName, index, _) = ResolveKey(paths[i]);
 
             if (i == paths.Length - 1)
             {
@@ -465,6 +471,10 @@ public class NginxConfig
                 if (current != null && current is GroupToken groupToken)
                 {
                     tokens = groupToken.Tokens.ToList();
+                }
+                else
+                {
+                    return new List<IValueToken>();
                 }
             }
         }
@@ -482,7 +492,7 @@ public class NginxConfig
         return tokens.Where(x => x is IValueToken valueToken && valueToken.Key == key).Cast<IValueToken>().ToArray();
     }
 
-    private (string key, int index) ResolveKey(string key)
+    private (string key, int index, bool hasIndex) ResolveKey(string key)
     {
         if (!KeyRegex.IsMatch(key))
         {
@@ -493,19 +503,21 @@ public class NginxConfig
 
         var index = 0;
         string keyName = key;
+        var hasIndex = false;
 
         if (numberStartSymbol > 0)
         {
+            hasIndex = true;
             var numberStartIndex = numberStartSymbol + 1;
 
             if (!int.TryParse(key.Substring(numberStartIndex, key.Length - 1 - numberStartIndex), out index))
             {
-                // TODO
+                throw new Exception($"The key '{key}' index format is incorrect");
             }
 
             keyName = key.Substring(0, numberStartSymbol);
         }
 
-        return (keyName, index);
+        return (keyName, index, hasIndex);
     }
 }

--- a/NginxConfigParser/NginxConfigParser.csproj
+++ b/NginxConfigParser/NginxConfigParser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net9.0;net10.0</TargetFrameworks>
     <Authors>Passingwind</Authors>
     <Version>0.1.4</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/NginxConfigParser/Parser.cs
+++ b/NginxConfigParser/Parser.cs
@@ -48,32 +48,39 @@ public class Parser
 
     private void ParseLine(string text, int lineIndex)
     {
-        var keyEndSymbol = text.IndexOf(' ');
-        var endSymbol = text.IndexOf(';');
-        var commentSymbol = text.IndexOf('#');
-        var groupStartSymbol = text.IndexOf('{');
-
         if (text.Length == 0)
         {
             return;
         }
 
+        // Full-line comment
         if (text[0] == '#')
         {
             var commentToken = new CommentToken(text.Trim().TrimStart('#').Trim());
             AddToken(commentToken);
             return;
         }
-        else if (text[0] == '\'')
-        {
-            if (_currentToken != null && _currentToken is ValueToken valueToken)
-            {
-                valueToken.Value += text.Trim();
 
-                if (endSymbol > -1)
+        // Group ending
+        if (text[0] == '}')
+        {
+            _currentGroupToken = _currentGroupToken?.Parent;
+            _currentToken = null;
+            return;
+        }
+
+        // Multi-line value continuation (historical support for lines starting with ')
+        if (text[0] == '\'')
+        {
+            if (_currentToken != null)
+            {
+                _currentToken.Value += text.Trim();
+
+                if (HasUnquotedStatementEnd(text))
                 {
-                    valueToken.Value = valueToken.Value.TrimEnd(';').Replace("\'\'", null);
-                    AddToken(valueToken);
+                    _currentToken.Value = _currentToken.Value.TrimEnd(';').Replace("\'\'", null);
+                    AddToken(_currentToken);
+                    _currentToken = null;
                 }
 
                 return;
@@ -81,58 +88,162 @@ public class Parser
 
             throw new Exception($"Unexpected quoted continuation at line {lineIndex}: {text}");
         }
-        else if (text[0] == '}')
+
+        var key = string.Empty;
+        var value = string.Empty;
+        var comment = string.Empty;
+        var keyEndSymbol = -1;
+        var groupStartSymbol = -1;
+        var endSymbol = -1;
+        var matchKey = false;
+        var isBetweenSingleQuote = false;
+        var isBetweenDoubleQuote = false;
+
+        for (var i = 0; i < text.Length; i++)
         {
-            _currentGroupToken = _currentGroupToken?.Parent;
+            var ch = text[i];
 
-            _currentToken = null;
+            // Toggle / stay inside single quotes (unless currently inside double quotes)
+            if (ch == '\'' && !isBetweenDoubleQuote)
+            {
+                isBetweenSingleQuote = !isBetweenSingleQuote;
+                continue;
+            }
 
-            return;
+            if (isBetweenSingleQuote)
+                continue;
+
+            // Toggle / stay inside double quotes
+            if (ch == '"')
+            {
+                isBetweenDoubleQuote = !isBetweenDoubleQuote;
+                continue;
+            }
+
+            if (isBetweenDoubleQuote)
+                continue;
+
+            // Outside quotes: structural characters
+            if (ch == ';')
+            {
+                endSymbol = i;
+                if (keyEndSymbol >= 0)
+                    value = text.Substring(keyEndSymbol + 1, endSymbol - keyEndSymbol - 1).Trim();
+                break;
+            }
+
+            if (ch == '{')
+            {
+                groupStartSymbol = i;
+                if (keyEndSymbol >= 0)
+                    value = text.Substring(keyEndSymbol + 1, groupStartSymbol - keyEndSymbol - 1).Trim();
+                break;
+            }
+
+            if (ch == '#')
+            {
+                if (keyEndSymbol >= 0)
+                    value = text.Substring(keyEndSymbol + 1, i - keyEndSymbol - 1).Trim();
+                comment = text.Substring(i + 1).Trim().TrimStart('#').Trim();
+                break;
+            }
+
+            if (ch == ' ' && !matchKey)
+            {
+                keyEndSymbol = i;
+                matchKey = true;
+                key = text.Substring(0, keyEndSymbol).Trim();
+            }
         }
 
-        string key = string.Empty;
-        string value = string.Empty;
-        string comment = string.Empty;
-
-        if (keyEndSymbol > -1)
-            key = text.Substring(0, keyEndSymbol);
-
-        if (groupStartSymbol > keyEndSymbol)
-        {
-            value = text.Substring(keyEndSymbol + 1, groupStartSymbol - keyEndSymbol - 1);
-        }
-        else if (endSymbol > keyEndSymbol)
-        {
-            value = text.Substring(keyEndSymbol + 1, endSymbol - keyEndSymbol - 1);
-        }
-        else if (endSymbol == -1)
-        {
-            value = text.Substring(keyEndSymbol + 1);
-        }
-
-        if (commentSymbol > keyEndSymbol)
-            comment = text.Substring(commentSymbol + 1).Trim().TrimStart('#').Trim();
+        if (isBetweenSingleQuote || isBetweenDoubleQuote)
+            throw new Exception($"Unpaired quote detected at line {lineIndex}: {text}");
 
         if (groupStartSymbol > -1)
         {
+            // Inline comment after {: "server { # comment"
+            if (string.IsNullOrEmpty(comment))
+            {
+                var afterGroup = groupStartSymbol + 1;
+                if (afterGroup < text.Length)
+                {
+                    var inline = text.Substring(afterGroup).Trim();
+                    if (inline.StartsWith("#", StringComparison.Ordinal))
+                        comment = inline.TrimStart('#').Trim();
+                }
+            }
+
             var groupToken = new GroupToken(_currentGroupToken, key, value, comment);
             AddToken(groupToken);
             _currentGroupToken = groupToken;
             return;
         }
 
-        if (groupStartSymbol == -1 && endSymbol == -1)
+        if (endSymbol == -1 && groupStartSymbol == -1)
         {
+            if (keyEndSymbol >= 0 && string.IsNullOrEmpty(value))
+                value = text.Substring(keyEndSymbol + 1).Trim();
+
             _currentToken = new ValueToken(_currentGroupToken, key, value, comment);
             return;
         }
 
         if (endSymbol > -1)
         {
+            // Inline comment after semicolon: key value; # comment
+            if (string.IsNullOrEmpty(comment) && endSymbol + 1 < text.Length)
+            {
+                var afterEnd = text.Substring(endSymbol + 1).Trim();
+                if (afterEnd.StartsWith("#", StringComparison.Ordinal))
+                    comment = afterEnd.TrimStart('#').Trim();
+            }
+
             AddToken(new ValueToken(_currentGroupToken, key, value?.Trim(), comment));
             return;
         }
 
         throw new Exception($"Unable to parse line {lineIndex}: {text}");
+    }
+
+    /// <summary>
+    /// Returns true when the line contains a statement-ending ';' outside of quotes.
+    /// </summary>
+    private static bool HasUnquotedStatementEnd(string text)
+    {
+        return IndexOfUnquoted(text, ';') >= 0;
+    }
+
+    private static int IndexOfUnquoted(string text, char target)
+    {
+        var inSingle = false;
+        var inDouble = false;
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            var ch = text[i];
+
+            if (ch == '\'' && !inDouble)
+            {
+                inSingle = !inSingle;
+                continue;
+            }
+
+            if (inSingle)
+                continue;
+
+            if (ch == '"')
+            {
+                inDouble = !inDouble;
+                continue;
+            }
+
+            if (inDouble)
+                continue;
+
+            if (ch == target)
+                return i;
+        }
+
+        return -1;
     }
 }

--- a/NginxConfigParser/Parser.cs
+++ b/NginxConfigParser/Parser.cs
@@ -24,7 +24,7 @@ public class Parser
         var lineIndex = 0;
 
         StringReader sr = new StringReader(_content);
-        string line = string.Empty;
+        string line;
 
         while ((line = sr.ReadLine()) != null)
         {
@@ -50,9 +50,8 @@ public class Parser
     {
         var keyEndSymbol = text.IndexOf(' ');
         var endSymbol = text.IndexOf(';');
-        var commendSymbol = text.IndexOf('#');
+        var commentSymbol = text.IndexOf('#');
         var groupStartSymbol = text.IndexOf('{');
-        var groupEndSymbol = text.IndexOf('}');
 
         if (text.Length == 0)
         {
@@ -61,8 +60,8 @@ public class Parser
 
         if (text[0] == '#')
         {
-            var commendToken = new CommentToken(text.Trim().TrimStart('#').Trim());
-            AddToken(commendToken);
+            var commentToken = new CommentToken(text.Trim().TrimStart('#').Trim());
+            AddToken(commentToken);
             return;
         }
         else if (text[0] == '\'')
@@ -80,7 +79,7 @@ public class Parser
                 return;
             }
 
-            throw new Exception("");
+            throw new Exception($"Unexpected quoted continuation at line {lineIndex}: {text}");
         }
         else if (text[0] == '}')
         {
@@ -93,7 +92,7 @@ public class Parser
 
         string key = string.Empty;
         string value = string.Empty;
-        string commend = string.Empty;
+        string comment = string.Empty;
 
         if (keyEndSymbol > -1)
             key = text.Substring(0, keyEndSymbol);
@@ -111,12 +110,12 @@ public class Parser
             value = text.Substring(keyEndSymbol + 1);
         }
 
-        if (commendSymbol > keyEndSymbol)
-            commend = text.Substring(commendSymbol + 1).Trim().TrimStart('#').Trim();
+        if (commentSymbol > keyEndSymbol)
+            comment = text.Substring(commentSymbol + 1).Trim().TrimStart('#').Trim();
 
         if (groupStartSymbol > -1)
         {
-            var groupToken = new GroupToken(_currentGroupToken, key, value, commend);
+            var groupToken = new GroupToken(_currentGroupToken, key, value, comment);
             AddToken(groupToken);
             _currentGroupToken = groupToken;
             return;
@@ -124,16 +123,16 @@ public class Parser
 
         if (groupStartSymbol == -1 && endSymbol == -1)
         {
-            _currentToken = new ValueToken(_currentGroupToken, key, value, commend);
+            _currentToken = new ValueToken(_currentGroupToken, key, value, comment);
             return;
         }
 
         if (endSymbol > -1)
         {
-            AddToken(new ValueToken(_currentGroupToken, key, value?.Trim(), commend));
+            AddToken(new ValueToken(_currentGroupToken, key, value?.Trim(), comment));
             return;
         }
 
-        throw new Exception("");
+        throw new Exception($"Unable to parse line {lineIndex}: {text}");
     }
 }

--- a/NginxConfigParser/Token.cs
+++ b/NginxConfigParser/Token.cs
@@ -76,7 +76,3 @@ public class GroupToken : IValueToken
         return $"{Key} {Value} => [{Tokens.Count}]";
     }
 }
-
-public class RootToken
-{
-}

--- a/NginxConfigParser/TokenType.cs
+++ b/NginxConfigParser/TokenType.cs
@@ -1,8 +1,0 @@
-﻿namespace NginxConfigParser;
-
-internal enum TokenType
-{
-    Comment = 0,
-    KeyValue = 1,
-    Group = 2,
-}

--- a/NginxConfigParserTests/NginxConfigParserTests.csproj
+++ b/NginxConfigParserTests/NginxConfigParserTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/NginxConfigParserUnitTests/CommonNginxConfigTests.cs
+++ b/NginxConfigParserUnitTests/CommonNginxConfigTests.cs
@@ -1,0 +1,511 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+/// <summary>
+/// Coverage for common nginx.conf directives beyond the bundled test.conf sample.
+/// </summary>
+public class CommonNginxConfigTests
+{
+    [Fact]
+    public void Parses_GlobalWorkerAndProcessDirectives()
+    {
+        var config = NginxConfig.Load("""
+            user nginx;
+            worker_processes auto;
+            worker_rlimit_nofile 65535;
+            pid /run/nginx.pid;
+            error_log /var/log/nginx/error.log warn;
+            """);
+
+        Assert.Equal("nginx", config["user"]!.Value);
+        Assert.Equal("auto", config["worker_processes"]!.Value);
+        Assert.Equal("65535", config["worker_rlimit_nofile"]!.Value);
+        Assert.Equal("/run/nginx.pid", config["pid"]!.Value);
+        Assert.Equal("/var/log/nginx/error.log warn", config["error_log"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_EventsBlock()
+    {
+        var config = NginxConfig.Load("""
+            events {
+              use epoll;
+              multi_accept on;
+              worker_connections 10240;
+            }
+            """);
+
+        Assert.Equal("epoll", config["events:use"]!.Value);
+        Assert.Equal("on", config["events:multi_accept"]!.Value);
+        Assert.Equal("10240", config["events:worker_connections"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_HttpPerformanceAndGzipDirectives()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              sendfile on;
+              tcp_nopush on;
+              tcp_nodelay on;
+              keepalive_timeout 65;
+              types_hash_max_size 2048;
+              server_tokens off;
+              client_max_body_size 20m;
+              gzip on;
+              gzip_vary on;
+              gzip_proxied any;
+              gzip_comp_level 5;
+              gzip_types text/plain text/css application/json application/javascript;
+            }
+            """);
+
+        Assert.Equal("on", config["http:sendfile"]!.Value);
+        Assert.Equal("on", config["http:tcp_nopush"]!.Value);
+        Assert.Equal("on", config["http:tcp_nodelay"]!.Value);
+        Assert.Equal("65", config["http:keepalive_timeout"]!.Value);
+        Assert.Equal("2048", config["http:types_hash_max_size"]!.Value);
+        Assert.Equal("off", config["http:server_tokens"]!.Value);
+        Assert.Equal("20m", config["http:client_max_body_size"]!.Value);
+        Assert.Equal("on", config["http:gzip"]!.Value);
+        Assert.Equal("on", config["http:gzip_vary"]!.Value);
+        Assert.Equal("any", config["http:gzip_proxied"]!.Value);
+        Assert.Equal("5", config["http:gzip_comp_level"]!.Value);
+        Assert.Equal("text/plain text/css application/json application/javascript", config["http:gzip_types"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_SslServerBlock()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                listen 443 ssl http2;
+                listen [::]:443 ssl http2;
+                server_name example.com www.example.com;
+                ssl_certificate /etc/nginx/ssl/example.com.crt;
+                ssl_certificate_key /etc/nginx/ssl/example.com.key;
+                ssl_protocols TLSv1.2 TLSv1.3;
+                ssl_ciphers HIGH:!aNULL:!MD5;
+                ssl_session_cache shared:SSL:10m;
+                ssl_session_timeout 10m;
+                root /var/www/example;
+                index index.html index.htm;
+              }
+            }
+            """);
+
+        Assert.Equal("443 ssl http2", config["http:server:listen"]!.Value);
+        Assert.Equal("[::]:443 ssl http2", config["http:server:listen[1]"]!.Value);
+        Assert.Equal("example.com www.example.com", config["http:server:server_name"]!.Value);
+        Assert.Equal("/etc/nginx/ssl/example.com.crt", config["http:server:ssl_certificate"]!.Value);
+        Assert.Equal("/etc/nginx/ssl/example.com.key", config["http:server:ssl_certificate_key"]!.Value);
+        Assert.Equal("TLSv1.2 TLSv1.3", config["http:server:ssl_protocols"]!.Value);
+        Assert.Equal("HIGH:!aNULL:!MD5", config["http:server:ssl_ciphers"]!.Value);
+        Assert.Equal("shared:SSL:10m", config["http:server:ssl_session_cache"]!.Value);
+        Assert.Equal("10m", config["http:server:ssl_session_timeout"]!.Value);
+        Assert.Equal("/var/www/example", config["http:server:root"]!.Value);
+        Assert.Equal("index.html index.htm", config["http:server:index"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_HttpToHttpsRedirectServer()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                listen 80;
+                server_name example.com;
+                return 301 https://$host$request_uri;
+              }
+            }
+            """);
+
+        Assert.Equal("80", config["http:server:listen"]!.Value);
+        Assert.Equal("301 https://$host$request_uri", config["http:server:return"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_ReturnDirective_WithStatusAndUrl()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                location /old {
+                  return 301 https://example.com/new;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("301 https://example.com/new", config["http:server:location:return"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_ProxyPassAndProxyHeaders()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                location /api/ {
+                  proxy_pass http://backend;
+                  proxy_http_version 1.1;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto $scheme;
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection upgrade;
+                  proxy_read_timeout 60s;
+                  proxy_connect_timeout 5s;
+                  proxy_buffering off;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("http://backend", config["http:server:location:proxy_pass"]!.Value);
+        Assert.Equal("1.1", config["http:server:location:proxy_http_version"]!.Value);
+        Assert.Equal("Host $host", config["http:server:location:proxy_set_header"]!.Value);
+        Assert.Equal(6, config.GetTokens("http:server:location:proxy_set_header").Count);
+        Assert.Equal("60s", config["http:server:location:proxy_read_timeout"]!.Value);
+        Assert.Equal("5s", config["http:server:location:proxy_connect_timeout"]!.Value);
+        Assert.Equal("off", config["http:server:location:proxy_buffering"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_TryFilesAndStaticLocation()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                root /var/www/html;
+                location / {
+                  try_files $uri $uri/ /index.html;
+                }
+                location /assets/ {
+                  alias /var/www/assets/;
+                  expires 7d;
+                  access_log off;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("/var/www/html", config["http:server:root"]!.Value);
+        Assert.Equal("$uri $uri/ /index.html", config["http:server:location:try_files"]!.Value);
+        Assert.Equal("/assets/", config["http:server:location[1]"]!.Value);
+        Assert.Equal("/var/www/assets/", config["http:server:location[1]:alias"]!.Value);
+        Assert.Equal("7d", config["http:server:location[1]:expires"]!.Value);
+        Assert.Equal("off", config["http:server:location[1]:access_log"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_RewriteDirectives()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                location /blog {
+                  rewrite ^/blog/(.*)$ /index.php?post=$1 last;
+                  rewrite ^/feed$ /index.php?feed=rss permanent;
+                }
+              }
+            }
+            """);
+
+        var rewrites = config.GetTokens("http:server:location:rewrite");
+        Assert.Equal(2, rewrites.Count);
+        Assert.Equal("^/blog/(.*)$ /index.php?post=$1 last", rewrites[0].Value);
+        Assert.Equal("^/feed$ /index.php?feed=rss permanent", rewrites[1].Value);
+    }
+
+    [Fact]
+    public void Parses_UpstreamWithWeightsAndBackup()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              upstream app_servers {
+                server 10.0.0.1:8080 weight=3;
+                server 10.0.0.2:8080 weight=2;
+                server 10.0.0.3:8080 backup;
+                keepalive 32;
+              }
+              server {
+                location / {
+                  proxy_pass http://app_servers;
+                }
+              }
+            }
+            """);
+
+        var upstream = config.GetToken("http:upstream") as GroupToken;
+        Assert.NotNull(upstream);
+        Assert.Equal("app_servers", upstream.Value);
+
+        var servers = config.GetTokens("http:upstream:server");
+        Assert.Equal(3, servers.Count);
+        Assert.Equal("10.0.0.1:8080 weight=3", servers[0].Value);
+        Assert.Equal("10.0.0.2:8080 weight=2", servers[1].Value);
+        Assert.Equal("10.0.0.3:8080 backup", servers[2].Value);
+        Assert.Equal("32", config["http:upstream:keepalive"]!.Value);
+        Assert.Equal("http://app_servers", config["http:server:location:proxy_pass"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_FastcgiPhpLocation()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                root /var/www/wordpress;
+                index index.php;
+                location ~ \.php$ {
+                  include fastcgi_params;
+                  fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+                  fastcgi_pass unix:/run/php/php8.2-fpm.sock;
+                  fastcgi_index index.php;
+                  fastcgi_read_timeout 120;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("~ \\.php$", config["http:server:location"]!.Value);
+        Assert.Equal("fastcgi_params", config["http:server:location:include"]!.Value);
+        Assert.Equal("SCRIPT_FILENAME $document_root$fastcgi_script_name", config["http:server:location:fastcgi_param"]!.Value);
+        Assert.Equal("unix:/run/php/php8.2-fpm.sock", config["http:server:location:fastcgi_pass"]!.Value);
+        Assert.Equal("index.php", config["http:server:location:fastcgi_index"]!.Value);
+        Assert.Equal("120", config["http:server:location:fastcgi_read_timeout"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_MapBlock()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              map $http_upgrade $connection_upgrade {
+                default upgrade;
+                websocket upgrade;
+              }
+              server {
+                location / {
+                  proxy_set_header Upgrade $http_upgrade;
+                  proxy_set_header Connection $connection_upgrade;
+                }
+              }
+            }
+            """);
+
+        var map = config.GetToken("http:map") as GroupToken;
+        Assert.NotNull(map);
+        Assert.Equal("$http_upgrade $connection_upgrade", map.Value);
+        Assert.Equal("upgrade", config["http:map:default"]!.Value);
+        Assert.Equal("upgrade", config["http:map:websocket"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_LimitReqAndLimitConn()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              limit_req_zone $binary_remote_addr zone=one:10m rate=5r/s;
+              limit_conn_zone $binary_remote_addr zone=addr:10m;
+              server {
+                location /login {
+                  limit_req zone=one burst=10 nodelay;
+                  limit_conn addr 10;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("$binary_remote_addr zone=one:10m rate=5r/s", config["http:limit_req_zone"]!.Value);
+        Assert.Equal("$binary_remote_addr zone=addr:10m", config["http:limit_conn_zone"]!.Value);
+        Assert.Equal("zone=one burst=10 nodelay", config["http:server:location:limit_req"]!.Value);
+        Assert.Equal("addr 10", config["http:server:location:limit_conn"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_AddHeaderWithoutSemicolonInQuotes()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                add_header X-Frame-Options SAMEORIGIN;
+                add_header X-Content-Type-Options nosniff;
+                add_header Referrer-Policy no-referrer-when-downgrade;
+                add_header Strict-Transport-Security "max-age=31536000" always;
+              }
+            }
+            """);
+
+        var headers = config.GetTokens("http:server:add_header");
+        Assert.Equal(4, headers.Count);
+        Assert.Equal("X-Frame-Options SAMEORIGIN", headers[0].Value);
+        Assert.Equal("X-Content-Type-Options nosniff", headers[1].Value);
+        Assert.Equal("Referrer-Policy no-referrer-when-downgrade", headers[2].Value);
+        Assert.Equal("Strict-Transport-Security \"max-age=31536000\" always", headers[3].Value);
+    }
+
+    [Fact]
+    public void Parses_AccessDenyAndAllow()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                location /admin {
+                  allow 10.0.0.0/8;
+                  allow 192.168.0.0/16;
+                  deny all;
+                }
+              }
+            }
+            """);
+
+        var allows = config.GetTokens("http:server:location:allow");
+        Assert.Equal(2, allows.Count);
+        Assert.Equal("10.0.0.0/8", allows[0].Value);
+        Assert.Equal("192.168.0.0/16", allows[1].Value);
+        Assert.Equal("all", config["http:server:location:deny"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_TypesBlock()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              types {
+                text/html html htm shtml;
+                text/css css;
+                application/javascript js;
+                image/svg+xml svg svgz;
+              }
+              default_type application/octet-stream;
+            }
+            """);
+
+        var types = config.GetToken("http:types") as GroupToken;
+        Assert.NotNull(types);
+        // MIME type keys contain '/' / '+' so path API cannot address them; assert via group tokens.
+        Assert.Contains(types.Tokens, t => t is ValueToken v && v.Key == "text/html" && v.Value == "html htm shtml");
+        Assert.Contains(types.Tokens, t => t is ValueToken v && v.Key == "text/css" && v.Value == "css");
+        Assert.Contains(types.Tokens, t => t is ValueToken v && v.Key == "application/javascript" && v.Value == "js");
+        Assert.Contains(types.Tokens, t => t is ValueToken v && v.Key == "image/svg+xml" && v.Value == "svg svgz");
+        Assert.Equal("application/octet-stream", config["http:default_type"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_MultipleVhostsAndLocations()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                listen 80;
+                server_name api.example.com;
+                location /health {
+                  return 200 ok;
+                }
+                location /v1/ {
+                  proxy_pass http://api_v1;
+                }
+              }
+              server {
+                listen 80;
+                server_name static.example.com;
+                root /var/www/static;
+                location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+                  expires 30d;
+                  access_log off;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("api.example.com", config["http:server:server_name"]!.Value);
+        Assert.Equal("/health", config["http:server:location"]!.Value);
+        Assert.Equal("200 ok", config["http:server:location:return"]!.Value);
+        Assert.Equal("/v1/", config["http:server:location[1]"]!.Value);
+        Assert.Equal("http://api_v1", config["http:server:location[1]:proxy_pass"]!.Value);
+
+        Assert.Equal("static.example.com", config["http:server[1]:server_name"]!.Value);
+        Assert.Equal("/var/www/static", config["http:server[1]:root"]!.Value);
+        Assert.Equal("~* \\.(jpg|jpeg|png|gif|ico|css|js)$", config["http:server[1]:location"]!.Value);
+        Assert.Equal("30d", config["http:server[1]:location:expires"]!.Value);
+    }
+
+    [Fact]
+    public void Parses_LogFormatAndAccessLog()
+    {
+        // Single-line log_format (multi-line quoted forms are a known parser limitation).
+        var config = NginxConfig.Load("""
+            http {
+              log_format main $remote_addr - $remote_user [$time_local] $status;
+              log_format detailed $request_time $upstream_response_time;
+              access_log /var/log/nginx/access.log main;
+              access_log /var/log/nginx/detailed.log detailed;
+            }
+            """);
+
+        var formats = config.GetTokens("http:log_format");
+        Assert.Equal(2, formats.Count);
+        Assert.Equal("main $remote_addr - $remote_user [$time_local] $status", formats[0].Value);
+        Assert.Equal("detailed $request_time $upstream_response_time", formats[1].Value);
+
+        var logs = config.GetTokens("http:access_log");
+        Assert.Equal(2, logs.Count);
+        Assert.Equal("/var/log/nginx/access.log main", logs[0].Value);
+        Assert.Equal("/var/log/nginx/detailed.log detailed", logs[1].Value);
+    }
+
+    [Fact]
+    public void Parses_OpenFileCacheAndResolver()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              open_file_cache max=1000 inactive=20s;
+              open_file_cache_valid 30s;
+              open_file_cache_min_uses 2;
+              open_file_cache_errors on;
+              resolver 8.8.8.8 8.8.4.4 valid=300s;
+              resolver_timeout 5s;
+            }
+            """);
+
+        Assert.Equal("max=1000 inactive=20s", config["http:open_file_cache"]!.Value);
+        Assert.Equal("30s", config["http:open_file_cache_valid"]!.Value);
+        Assert.Equal("2", config["http:open_file_cache_min_uses"]!.Value);
+        Assert.Equal("on", config["http:open_file_cache_errors"]!.Value);
+        Assert.Equal("8.8.8.8 8.8.4.4 valid=300s", config["http:resolver"]!.Value);
+        Assert.Equal("5s", config["http:resolver_timeout"]!.Value);
+    }
+
+    [Fact]
+    public void RoundTrip_CommonReverseProxyConfig()
+    {
+        var original = NginxConfig.Create()
+            .AddOrUpdate("worker_processes", "auto")
+            .AddOrUpdate("events:worker_connections", "4096")
+            .AddOrUpdate("http:gzip", "on")
+            .AddOrUpdate("http:upstream", "backend", true)
+            .AddOrUpdate("http:upstream:server", "127.0.0.1:8080")
+            .AddOrUpdate("http:server:listen", "80")
+            .AddOrUpdate("http:server:server_name", "app.local")
+            .AddOrUpdate("http:server:location", "/", true)
+            .AddOrUpdate("http:server:location:proxy_pass", "http://backend")
+            .AddOrUpdate("http:server:location:proxy_set_header", "Host $host");
+
+        var reloaded = NginxConfig.Load(original.ToString());
+
+        Assert.Equal("auto", reloaded["worker_processes"]!.Value);
+        Assert.Equal("4096", reloaded["events:worker_connections"]!.Value);
+        Assert.Equal("on", reloaded["http:gzip"]!.Value);
+        Assert.Equal("backend", reloaded["http:upstream"]!.Value);
+        Assert.Equal("127.0.0.1:8080", reloaded["http:upstream:server"]!.Value);
+        Assert.Equal("app.local", reloaded["http:server:server_name"]!.Value);
+        Assert.Equal("http://backend", reloaded["http:server:location:proxy_pass"]!.Value);
+        Assert.Equal("Host $host", reloaded["http:server:location:proxy_set_header"]!.Value);
+    }
+}

--- a/NginxConfigParserUnitTests/CreateAndBuilderTests.cs
+++ b/NginxConfigParserUnitTests/CreateAndBuilderTests.cs
@@ -1,0 +1,78 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+public class CreateAndBuilderTests
+{
+    [Fact]
+    public void Create_ReturnsEmptyConfig()
+    {
+        var config = NginxConfig.Create();
+
+        Assert.Empty(config.GetTokens());
+        Assert.Equal(string.Empty, config.ToString());
+    }
+
+    [Fact]
+    public void AddOrUpdate_CreatesNestedValues()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("http:server:listen", "80")
+            .AddOrUpdate("http:server:root", "/var/wwwroot");
+
+        Assert.Equal("80", config["http:server:listen"]!.Value);
+        Assert.Equal("/var/wwwroot", config.GetToken("http:server:root")!.Value);
+    }
+
+    [Fact]
+    public void AddOrUpdate_AddAsGroup_CreatesGroupWithValue()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("http:server:location", "/", true, "default")
+            .AddOrUpdate("http:server:location:root", "/app1");
+
+        var location = config.GetToken("http:server:location");
+        Assert.NotNull(location);
+        Assert.IsType<GroupToken>(location);
+        Assert.Equal("/", location.Value);
+        Assert.Equal("default", location.Comment);
+        Assert.Equal("/app1", config["http:server:location:root"]!.Value);
+    }
+
+    [Fact]
+    public void AddOrUpdate_MultipleIndexedGroups()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("http:server:location", "/", true, "default")
+            .AddOrUpdate("http:server:location:root", "/app1")
+            .AddOrUpdate("http:server:location[1]", "~ ^/static/", true)
+            .AddOrUpdate("http:server:location[1]:root", "/app2")
+            .AddOrUpdate("http:server:location[1]:expires", "1d");
+
+        Assert.Equal("/", config["http:server:location"]!.Value);
+        Assert.Equal("~ ^/static/", config["http:server:location[1]"]!.Value);
+        Assert.Equal("/app2", config["http:server:location[1]:root"]!.Value);
+        Assert.Equal("1d", config["http:server:location[1]:expires"]!.Value);
+    }
+
+    [Fact]
+    public void AddOrUpdate_UpdatesExistingValueAndComment()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("worker_processes", "1")
+            .AddOrUpdate("worker_processes", "4", comment: "updated");
+
+        Assert.Equal("4", config["worker_processes"]!.Value);
+        Assert.Equal("updated", config["worker_processes"]!.Comment);
+    }
+
+    [Fact]
+    public void AddOrUpdate_IsFluent()
+    {
+        var config = NginxConfig.Create();
+        var same = config.AddOrUpdate("pid", "logs/nginx.pid");
+
+        Assert.Same(config, same);
+    }
+}

--- a/NginxConfigParserUnitTests/ErrorAndEdgeCaseTests.cs
+++ b/NginxConfigParserUnitTests/ErrorAndEdgeCaseTests.cs
@@ -1,0 +1,85 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+public class ErrorAndEdgeCaseTests
+{
+    [Fact]
+    public void AddOrUpdate_EmptyKeyPath_Throws()
+    {
+        var config = NginxConfig.Create();
+        Assert.Throws<ArgumentException>(() => config.AddOrUpdate("", "1"));
+        Assert.Throws<ArgumentException>(() => config.Remove(" "));
+    }
+
+    [Fact]
+    public void Save_EmptyFileName_Throws()
+    {
+        var config = NginxConfig.Create();
+        Assert.Throws<ArgumentException>(() => config.Save(""));
+        Assert.Throws<ArgumentNullException>(() => config.Save("out.conf", null!));
+    }
+
+    [Fact]
+    public void Parser_UnexpectedQuotedLine_IncludesLineNumber()
+    {
+        var ex = Assert.Throws<Exception>(() => NginxConfig.Load("""
+            'orphaned continuation';
+            """));
+
+        Assert.Contains("line 1", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetTokens_RootLevelDuplicates()
+    {
+        var config = NginxConfig.Load("""
+            include a.conf;
+            include b.conf;
+            """);
+
+        var includes = config.GetTokens("include");
+        Assert.Equal(2, includes.Count);
+    }
+
+    [Fact]
+    public void CommentOnlyFile_ParsesWithoutValues()
+    {
+        var config = NginxConfig.Load("""
+            # only a comment
+            """);
+
+        var tokens = config.GetTokens().ToList();
+        Assert.Single(tokens);
+        Assert.IsType<CommentToken>(tokens[0]);
+    }
+
+    [Fact]
+    public void GroupWithValue_ParsesLocationModifier()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                location ~ \.php$ {
+                  fastcgi_pass 127.0.0.1:1025;
+                }
+              }
+            }
+            """);
+
+        Assert.Equal("~ \\.php$", config["http:server:location"]!.Value);
+        Assert.Equal("127.0.0.1:1025", config["http:server:location:fastcgi_pass"]!.Value);
+    }
+
+    [Fact]
+    public void TokenModel_ValueAndGroupToString()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("pid", "a.pid", comment: "c")
+            .AddOrUpdate("http:server", null!, true, "srv");
+
+        Assert.Contains("# c", config["pid"]!.ToString(), StringComparison.Ordinal);
+        Assert.Contains("server", config["http:server"]!.ToString(), StringComparison.Ordinal);
+    }
+}

--- a/NginxConfigParserUnitTests/LoadAndParseTests.cs
+++ b/NginxConfigParserUnitTests/LoadAndParseTests.cs
@@ -1,0 +1,160 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+public class LoadAndParseTests
+{
+    [Fact]
+    public void Load_ParsesRootLevelKeys()
+    {
+        var config = NginxConfig.Load("""
+            worker_processes  5;
+            error_log  logs/error.log;
+            """);
+
+        Assert.Equal("5", config["worker_processes"]!.Value);
+        Assert.Equal("logs/error.log", config["error_log"]!.Value);
+    }
+
+    [Fact]
+    public void Load_ParsesNestedGroups()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              sendfile     on;
+              server {
+                listen 80;
+                root html;
+              }
+            }
+            """);
+
+        Assert.Equal("on", config["http:sendfile"]!.Value);
+        Assert.Equal("80", config["http:server:listen"]!.Value);
+        Assert.Equal("html", config["http:server:root"]!.Value);
+    }
+
+    [Fact]
+    public void Load_ParsesMultipleSameNameGroups()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                listen 80;
+                server_name a.com;
+              }
+              server {
+                listen 8080;
+                server_name b.com;
+              }
+            }
+            """);
+
+        Assert.Equal("80", config["http:server:listen"]!.Value);
+        Assert.Equal("8080", config["http:server[1]:listen"]!.Value);
+        Assert.Equal("a.com", config["http:server:server_name"]!.Value);
+        Assert.Equal("b.com", config["http:server[1]:server_name"]!.Value);
+    }
+
+    [Fact]
+    public void Load_ParsesMultipleSameNameValues()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              include    conf/mime.types;
+              include    /etc/nginx/proxy.conf;
+              include    /etc/nginx/fastcgi.conf;
+            }
+            """);
+
+        var includes = config.GetTokens("http:include");
+        Assert.Equal(3, includes.Count);
+        Assert.Equal("conf/mime.types", includes[0].Value);
+        Assert.Equal("/etc/nginx/proxy.conf", includes[1].Value);
+        Assert.Equal("/etc/nginx/fastcgi.conf", includes[2].Value);
+    }
+
+    [Fact]
+    public void Load_SkipsEmptyLines()
+    {
+        var config = NginxConfig.Load("""
+
+            worker_processes  1;
+
+            events {
+              worker_connections  1024;
+            }
+
+            """);
+
+        Assert.Equal("1", config["worker_processes"]!.Value);
+        Assert.Equal("1024", config["events:worker_connections"]!.Value);
+    }
+
+    [Fact]
+    public void Load_ParsesFullLineComments()
+    {
+        var config = NginxConfig.Load("""
+            # top comment
+            worker_processes  1;
+            http {
+              # inside comment
+              sendfile on;
+            }
+            """);
+
+        var tokens = config.GetTokens().ToList();
+        Assert.Contains(tokens, t => t is CommentToken c && c.Content == "top comment");
+
+        var http = config.GetGroup("http");
+        Assert.NotNull(http);
+        Assert.Contains(http.Tokens, t => t is CommentToken c && c.Content == "inside comment");
+    }
+
+    [Fact]
+    public void Load_ParsesInlineComments()
+    {
+        var config = NginxConfig.Load("""
+            worker_processes  5;  ## Default: 1
+            events {
+              worker_connections  4096;  ## Default: 1024
+            }
+            """);
+
+        Assert.Equal("Default: 1", config["worker_processes"]!.Comment);
+        Assert.Equal("Default: 1024", config["events:worker_connections"]!.Comment);
+    }
+
+    [Fact]
+    public void LoadFrom_ReadsTestConfSample()
+    {
+        var config = NginxConfig.LoadFrom("test.conf");
+
+        Assert.Equal("5", config["worker_processes"]!.Value);
+        Assert.Equal("logs/error.log", config["error_log"]!.Value);
+        Assert.NotNull(config.GetGroup("http"));
+        Assert.Equal("on", config["http:sendfile"]!.Value);
+
+        var servers = config.GetTokens("http:server");
+        Assert.True(servers.Count >= 2);
+    }
+
+    [Fact]
+    public void Load_NullContent_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => NginxConfig.Load(null!));
+    }
+
+    [Fact]
+    public void LoadFrom_MissingFile_Throws()
+    {
+        Assert.Throws<FileNotFoundException>(() => NginxConfig.LoadFrom("does-not-exist.conf"));
+    }
+
+    [Fact]
+    public void LoadFrom_WhitespacePath_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => NginxConfig.LoadFrom("  "));
+    }
+}

--- a/NginxConfigParserUnitTests/NginxConfigParserUnitTests.csproj
+++ b/NginxConfigParserUnitTests/NginxConfigParserUnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NginxConfigParser\NginxConfigParser.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\NginxConfigParserTests\test.conf" Link="test.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/NginxConfigParserUnitTests/PathApiTests.cs
+++ b/NginxConfigParserUnitTests/PathApiTests.cs
@@ -1,0 +1,116 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+public class PathApiTests
+{
+    private static NginxConfig Sample() => NginxConfig.Load("""
+        error_log  logs/error.log;
+        http {
+          sendfile on;
+          include a.conf;
+          include b.conf;
+          server {
+            listen 80;
+            root /a;
+          }
+          server {
+            listen 8080;
+            root /b;
+          }
+        }
+        """);
+
+    [Fact]
+    public void GetToken_And_Indexer_ReturnSameValue()
+    {
+        var config = Sample();
+
+        Assert.Equal(config.GetToken("http:sendfile")!.Value, config["http:sendfile"]!.Value);
+        Assert.Equal("logs/error.log", config["error_log"]!.Value);
+    }
+
+    [Fact]
+    public void GetToken_MissingPath_ReturnsNull()
+    {
+        var config = Sample();
+
+        Assert.Null(config.GetToken("http:missing"));
+        Assert.Null(config["http:server[9]:root"]);
+    }
+
+    [Fact]
+    public void GetTokens_ReturnsAllMatches()
+    {
+        var config = Sample();
+        var includes = config.GetTokens("http:include");
+
+        Assert.Equal(2, includes.Count);
+        Assert.Equal("a.conf", includes[0].Value);
+        Assert.Equal("b.conf", includes[1].Value);
+    }
+
+    [Fact]
+    public void GetTokens_MissingPath_ReturnsEmptyList()
+    {
+        var config = Sample();
+
+        var missing = config.GetTokens("http:does_not_exist");
+        Assert.NotNull(missing);
+        Assert.Empty(missing);
+
+        var nestedMissing = config.GetTokens("missing:include");
+        Assert.NotNull(nestedMissing);
+        Assert.Empty(nestedMissing);
+    }
+
+    [Fact]
+    public void GetGroup_ReturnsRootGroup()
+    {
+        var config = Sample();
+        var http = config.GetGroup("http");
+
+        Assert.NotNull(http);
+        Assert.Equal("http", http.Key);
+        Assert.Contains(http.Tokens, t => t is ValueToken v && v.Key == "sendfile");
+    }
+
+    [Fact]
+    public void GetGroup_Missing_ReturnsNull()
+    {
+        var config = Sample();
+        Assert.Null(config.GetGroup("stream"));
+    }
+
+    [Fact]
+    public void IndexedPath_SelectsCorrectServer()
+    {
+        var config = Sample();
+
+        Assert.Equal("/a", config["http:server[0]:root"]!.Value);
+        Assert.Equal("/b", config["http:server[1]:root"]!.Value);
+        Assert.Equal("80", config["http:server:listen"]!.Value);
+        Assert.Equal("8080", config["http:server[1]:listen"]!.Value);
+    }
+
+    [Fact]
+    public void EmptyKeyPath_Throws()
+    {
+        var config = Sample();
+
+        Assert.Throws<ArgumentException>(() => config.GetToken(""));
+        Assert.Throws<ArgumentException>(() => config.GetTokens(" "));
+        Assert.Throws<ArgumentException>(() => _ = config["\t"]);
+        Assert.Throws<ArgumentException>(() => config.GetGroup(null!));
+    }
+
+    [Fact]
+    public void InvalidKeyFormat_Throws()
+    {
+        var config = Sample();
+
+        Assert.ThrowsAny<Exception>(() => config.GetToken("http:bad-key"));
+        Assert.ThrowsAny<Exception>(() => config.GetToken("http:server[abc]:root"));
+    }
+}

--- a/NginxConfigParserUnitTests/QuotedValueParsingTests.cs
+++ b/NginxConfigParserUnitTests/QuotedValueParsingTests.cs
@@ -1,0 +1,144 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+/// <summary>
+/// Regression tests for https://github.com/jxnkwlp/NginxConfigParser/issues/15
+/// Semicolons / hashes inside quoted values must not terminate the statement.
+/// </summary>
+public class QuotedValueParsingTests
+{
+    [Fact]
+    public void Issue15_AddHeader_SemicolonInsideDoubleQuotes_IsPreserved()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                add_header X-Xss-Protection "1;mode=block";
+              }
+            }
+            """);
+
+        Assert.Equal("X-Xss-Protection \"1;mode=block\"", config["http:server:add_header"]!.Value);
+    }
+
+    [Fact]
+    public void Issue15_RoundTrip_PreservesQuotedSemicolon()
+    {
+        var original = NginxConfig.Load("""
+            http {
+              server {
+                add_header X-Xss-Protection "1;mode=block";
+              }
+            }
+            """);
+
+        var reloaded = NginxConfig.Load(original.ToString());
+
+        Assert.Equal("X-Xss-Protection \"1;mode=block\"", reloaded["http:server:add_header"]!.Value);
+        Assert.Contains("\"1;mode=block\"", reloaded.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SemicolonInsideSingleQuotes_IsPreserved()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                add_header X-Custom 'a;b;c';
+              }
+            }
+            """);
+
+        Assert.Equal("X-Custom 'a;b;c'", config["http:server:add_header"]!.Value);
+    }
+
+    [Fact]
+    public void HashInsideDoubleQuotes_IsNotTreatedAsComment()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              set $foo "bar#baz";
+            }
+            """);
+
+        Assert.Equal("$foo \"bar#baz\"", config["http:set"]!.Value);
+        Assert.True(string.IsNullOrEmpty(config["http:set"]!.Comment));
+    }
+
+    [Fact]
+    public void TrailingComment_StillParsed_WhenValueHasQuotedSemicolon()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                add_header X-Xss-Protection "1;mode=block"; # security
+              }
+            }
+            """);
+
+        var token = config["http:server:add_header"];
+        Assert.Equal("X-Xss-Protection \"1;mode=block\"", token!.Value);
+        Assert.Equal("security", token.Comment);
+    }
+
+    [Fact]
+    public void MultipleAddHeaders_WithQuotedSemicolons()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                add_header X-Xss-Protection "1;mode=block";
+                add_header Content-Security-Policy "default-src 'self'; script-src 'self'";
+                add_header X-Frame-Options SAMEORIGIN;
+              }
+            }
+            """);
+
+        var headers = config.GetTokens("http:server:add_header");
+        Assert.Equal(3, headers.Count);
+        Assert.Equal("X-Xss-Protection \"1;mode=block\"", headers[0].Value);
+        Assert.Equal("Content-Security-Policy \"default-src 'self'; script-src 'self'\"", headers[1].Value);
+        Assert.Equal("X-Frame-Options SAMEORIGIN", headers[2].Value);
+    }
+
+    [Fact]
+    public void BraceInsideQuotes_DoesNotStartGroup()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              set $msg "hello{world}";
+            }
+            """);
+
+        Assert.Equal("$msg \"hello{world}\"", config["http:set"]!.Value);
+        Assert.IsType<ValueToken>(config["http:set"]);
+    }
+
+    [Fact]
+    public void UnpairedDoubleQuote_ThrowsWithLineNumber()
+    {
+        var ex = Assert.Throws<Exception>(() => NginxConfig.Load("""
+            http {
+              add_header X-Test "unclosed;
+            }
+            """));
+
+        Assert.Contains("Unpaired quote", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("line", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Builder_CanCreateQuotedSemicolonValue()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("http:server:add_header", "X-Xss-Protection \"1;mode=block\"", addAsGroup: false);
+
+        var output = config.ToString();
+        Assert.Contains("\"1;mode=block\"", output, StringComparison.Ordinal);
+
+        var reloaded = NginxConfig.Load(output);
+        Assert.Equal("X-Xss-Protection \"1;mode=block\"", reloaded["http:server:add_header"]!.Value);
+    }
+}

--- a/NginxConfigParserUnitTests/SerializationTests.cs
+++ b/NginxConfigParserUnitTests/SerializationTests.cs
@@ -1,0 +1,136 @@
+using System.Text;
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+public class SerializationTests
+{
+    [Fact]
+    public void ToString_PreservesRelativeOrderOfValuesAndGroups()
+    {
+        var config = NginxConfig.Load("""
+            worker_processes 1;
+            events {
+              worker_connections 1024;
+            }
+            error_log logs/error.log;
+            http {
+              sendfile on;
+            }
+            """);
+
+        var output = config.ToString();
+        var workerPos = output.IndexOf("worker_processes", StringComparison.Ordinal);
+        var eventsPos = output.IndexOf("events", StringComparison.Ordinal);
+        var errorLogPos = output.IndexOf("error_log", StringComparison.Ordinal);
+        var httpPos = output.IndexOf("http", StringComparison.Ordinal);
+
+        Assert.True(workerPos >= 0);
+        Assert.True(eventsPos > workerPos);
+        Assert.True(errorLogPos > eventsPos);
+        Assert.True(httpPos > errorLogPos);
+    }
+
+    [Fact]
+    public void ToString_PreservesOrderInsideGroup()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              include a.conf;
+              server {
+                listen 80;
+              }
+              sendfile on;
+            }
+            """);
+
+        var output = config.ToString();
+        var includePos = output.IndexOf("include", StringComparison.Ordinal);
+        var serverPos = output.IndexOf("server", StringComparison.Ordinal);
+        var sendfilePos = output.IndexOf("sendfile", StringComparison.Ordinal);
+
+        Assert.True(includePos >= 0);
+        Assert.True(serverPos > includePos);
+        Assert.True(sendfilePos > serverPos);
+    }
+
+    [Fact]
+    public void RoundTrip_KeyValuesSurviveReload()
+    {
+        var original = NginxConfig.Create()
+            .AddOrUpdate("worker_processes", "2")
+            .AddOrUpdate("http:server:listen", "80")
+            .AddOrUpdate("http:server:root", "/var/www")
+            .AddOrUpdate("http:server:location", "/", true, "default")
+            .AddOrUpdate("http:server:location:root", "/app");
+
+        var reloaded = NginxConfig.Load(original.ToString());
+
+        Assert.Equal("2", reloaded["worker_processes"]!.Value);
+        Assert.Equal("80", reloaded["http:server:listen"]!.Value);
+        Assert.Equal("/var/www", reloaded["http:server:root"]!.Value);
+        Assert.Equal("/", reloaded["http:server:location"]!.Value);
+        Assert.Equal("default", reloaded["http:server:location"]!.Comment);
+        Assert.Equal("/app", reloaded["http:server:location:root"]!.Value);
+    }
+
+    [Fact]
+    public void Save_WritesUtf8File()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nginx-config-{Guid.NewGuid():N}.conf");
+        try
+        {
+            NginxConfig.Create()
+                .AddOrUpdate("worker_processes", "1")
+                .Save(path);
+
+            var bytes = File.ReadAllBytes(path);
+            Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+
+            var reloaded = NginxConfig.LoadFrom(path);
+            Assert.Equal("1", reloaded["worker_processes"]!.Value);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Save_WithEncoding_UsesProvidedEncoding()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nginx-config-{Guid.NewGuid():N}.conf");
+        try
+        {
+            NginxConfig.Create()
+                .AddOrUpdate("pid", "nginx.pid")
+                .Save(path, Encoding.Unicode);
+
+            var text = File.ReadAllText(path, Encoding.Unicode);
+            Assert.Contains("pid", text, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void BuiltConfig_MatchesExpectedStructure()
+    {
+        var content = NginxConfig.Create()
+            .AddOrUpdate("http:server:listen", "80")
+            .AddOrUpdate("http:server:location", "/", true, "default")
+            .AddOrUpdate("http:server:location:root", "/app1")
+            .ToString();
+
+        Assert.Contains("http", content, StringComparison.Ordinal);
+        Assert.Contains("server", content, StringComparison.Ordinal);
+        Assert.Contains("listen  80;", content, StringComparison.Ordinal);
+        Assert.Contains("location  / { # default", content, StringComparison.Ordinal);
+        Assert.Contains("root  /app1;", content, StringComparison.Ordinal);
+    }
+}

--- a/NginxConfigParserUnitTests/TestConfSampleTests.cs
+++ b/NginxConfigParserUnitTests/TestConfSampleTests.cs
@@ -1,0 +1,100 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+/// <summary>
+/// Deeper assertions against the bundled test.conf sample.
+/// </summary>
+public class TestConfSampleTests
+{
+    private static NginxConfig LoadSample() => NginxConfig.LoadFrom("test.conf");
+
+    [Fact]
+    public void TestConf_ParsesRootDirectives()
+    {
+        var config = LoadSample();
+
+        Assert.Equal("www www", config["user"]!.Value);
+        Assert.Equal("5", config["worker_processes"]!.Value);
+        Assert.Equal("logs/error.log", config["error_log"]!.Value);
+        Assert.Equal("logs/nginx.pid", config["pid"]!.Value);
+        Assert.Equal("8192", config["worker_rlimit_nofile"]!.Value);
+        Assert.Equal("4096", config["events:worker_connections"]!.Value);
+    }
+
+    [Fact]
+    public void TestConf_ParsesHttpIncludesAndBasics()
+    {
+        var config = LoadSample();
+
+        var includes = config.GetTokens("http:include");
+        Assert.Equal(3, includes.Count);
+        Assert.Equal("conf/mime.types", includes[0].Value);
+        Assert.Equal("/etc/nginx/proxy.conf", includes[1].Value);
+        Assert.Equal("/etc/nginx/fastcgi.conf", includes[2].Value);
+
+        Assert.Equal("index.html index.htm index.php", config["http:index"]!.Value);
+        Assert.Equal("application/octet-stream", config["http:default_type"]!.Value);
+        Assert.Equal("on", config["http:sendfile"]!.Value);
+        Assert.Equal("on", config["http:tcp_nopush"]!.Value);
+        Assert.Equal("128", config["http:server_names_hash_bucket_size"]!.Value);
+        Assert.Equal("logs/access.log  main", config["http:access_log"]!.Value);
+    }
+
+    [Fact]
+    public void TestConf_ParsesThreeServers()
+    {
+        var config = LoadSample();
+        var servers = config.GetTokens("http:server");
+
+        Assert.Equal(3, servers.Count);
+        Assert.Equal("php/fastcgi", servers[0].Comment);
+        Assert.Equal("simple reverse-proxy", servers[1].Comment);
+        Assert.Equal("simple load balancing", servers[2].Comment);
+
+        Assert.Equal("domain1.com www.domain1.com", config["http:server:server_name"]!.Value);
+        Assert.Equal("html", config["http:server:root"]!.Value);
+        Assert.Equal("~ \\.php$", config["http:server:location"]!.Value);
+        Assert.Equal("127.0.0.1:1025", config["http:server:location:fastcgi_pass"]!.Value);
+
+        Assert.Equal("domain2.com www.domain2.com", config["http:server[1]:server_name"]!.Value);
+        Assert.Equal("~ ^/(images|javascript|js|css|flash|media|static)/", config["http:server[1]:location"]!.Value?.Trim());
+        Assert.Equal("/var/www/virtual/big.server.com/htdocs", config["http:server[1]:location:root"]!.Value);
+        Assert.Equal("30d", config["http:server[1]:location:expires"]!.Value);
+        Assert.Equal("/", config["http:server[1]:location[1]"]!.Value);
+        Assert.Equal("http://127.0.0.1:8080", config["http:server[1]:location[1]:proxy_pass"]!.Value);
+
+        Assert.Equal("big.server.com", config["http:server[2]:server_name"]!.Value);
+        Assert.Equal("http://big_server_com", config["http:server[2]:location:proxy_pass"]!.Value);
+    }
+
+    [Fact]
+    public void TestConf_ParsesUpstream()
+    {
+        var config = LoadSample();
+        var upstream = config.GetToken("http:upstream") as GroupToken;
+
+        Assert.NotNull(upstream);
+        Assert.Equal("big_server_com", upstream.Value);
+
+        var servers = config.GetTokens("http:upstream:server");
+        Assert.Equal(4, servers.Count);
+        Assert.Equal("127.0.0.3:8000 weight=5", servers[0].Value);
+        Assert.Equal("127.0.0.3:8001 weight=5", servers[1].Value);
+        Assert.Equal("192.168.0.1:8000", servers[2].Value);
+        Assert.Equal("192.168.0.1:8001", servers[3].Value);
+    }
+
+    [Fact]
+    public void TestConf_GetGroupHttp_ContainsExpectedChildren()
+    {
+        var config = LoadSample();
+        var http = config.GetGroup("http");
+
+        Assert.NotNull(http);
+        Assert.Contains(http.Tokens, t => t is GroupToken g && g.Key == "server");
+        Assert.Contains(http.Tokens, t => t is GroupToken g && g.Key == "upstream");
+        Assert.Contains(http.Tokens, t => t is ValueToken v && v.Key == "sendfile");
+    }
+}

--- a/NginxConfigParserUnitTests/UpdateAndRemoveTests.cs
+++ b/NginxConfigParserUnitTests/UpdateAndRemoveTests.cs
@@ -1,0 +1,147 @@
+using NginxConfigParser;
+using Xunit;
+
+namespace NginxConfigParserUnitTests;
+
+public class UpdateAndRemoveTests
+{
+    [Fact]
+    public void AddOrUpdate_UpdatesExistingNestedValue()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              sendfile on;
+              server {
+                root /old;
+              }
+            }
+            """);
+
+        config.AddOrUpdate("http:sendfile", "off", comment: "updated");
+        config.AddOrUpdate("http:server:root", "/new", comment: "changed");
+
+        Assert.Equal("off", config["http:sendfile"]!.Value);
+        Assert.Equal("updated", config["http:sendfile"]!.Comment);
+        Assert.Equal("/new", config["http:server:root"]!.Value);
+    }
+
+    [Fact]
+    public void AddOrUpdate_CreatesIntermediateGroups()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("http:server2:root", "/var/wwwroot");
+
+        Assert.Equal("/var/wwwroot", config["http:server2:root"]!.Value);
+        Assert.IsType<GroupToken>(config.GetToken("http"));
+        Assert.IsType<GroupToken>(config.GetToken("http:server2"));
+    }
+
+    [Fact]
+    public void AddOrUpdate_IndexOutOfRange_Throws()
+    {
+        var config = NginxConfig.Create()
+            .AddOrUpdate("http:server:listen", "80");
+
+        Assert.Throws<IndexOutOfRangeException>(() =>
+            config.AddOrUpdate("http:server[2]:root", "/x"));
+    }
+
+    [Fact]
+    public void Remove_WithoutIndex_RemovesAllMatching()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              include a.conf;
+              include b.conf;
+              sendfile on;
+            }
+            """);
+
+        config.Remove("http:include");
+
+        Assert.Empty(config.GetTokens("http:include"));
+        Assert.Equal("on", config["http:sendfile"]!.Value);
+    }
+
+    [Fact]
+    public void Remove_WithIndex_RemovesOnlyThatItem()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              include a.conf;
+              include b.conf;
+              include c.conf;
+            }
+            """);
+
+        config.Remove("http:include[1]");
+
+        var includes = config.GetTokens("http:include");
+        Assert.Equal(2, includes.Count);
+        Assert.Equal("a.conf", includes[0].Value);
+        Assert.Equal("c.conf", includes[1].Value);
+    }
+
+    [Fact]
+    public void Remove_IndexedGroup()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              server {
+                listen 80;
+              }
+              server {
+                listen 8080;
+              }
+              server {
+                listen 9090;
+              }
+            }
+            """);
+
+        config.Remove("http:server[1]");
+
+        var servers = config.GetTokens("http:server");
+        Assert.Equal(2, servers.Count);
+        Assert.Equal("80", config["http:server:listen"]!.Value);
+        Assert.Equal("9090", config["http:server[1]:listen"]!.Value);
+    }
+
+    [Fact]
+    public void Remove_EntireGroup()
+    {
+        var config = NginxConfig.Load("""
+            events {
+              worker_connections 1024;
+            }
+            http {
+              sendfile on;
+            }
+            """);
+
+        config.Remove("events");
+
+        Assert.Null(config.GetGroup("events"));
+        Assert.NotNull(config.GetGroup("http"));
+    }
+
+    [Fact]
+    public void Remove_IndexOutOfRange_Throws()
+    {
+        var config = NginxConfig.Load("""
+            http {
+              include a.conf;
+            }
+            """);
+
+        Assert.Throws<IndexOutOfRangeException>(() => config.Remove("http:include[3]"));
+    }
+
+    [Fact]
+    public void Remove_IsFluent()
+    {
+        var config = NginxConfig.Create().AddOrUpdate("pid", "a.pid");
+        Assert.Same(config, config.Remove("pid"));
+        Assert.Null(config["pid"]);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Library now targets `netstandard2.0;netstandard2.1;net9.0;net10.0`
- Demo (`NginxConfigParserTests`) and new `NginxConfigParserUnitTests` use `net10.0`
- CI (`build.yml` / `pack.yml`) uses .NET 10 SDK; build workflow runs `dotnet test`

## Fixes (public API unchanged)

- **Serialization**: `WriteTokenString` preserves token order instead of forcing values-then-groups
- **Save**: default encoding is UTF-8 without BOM
- **GetTokens**: missing paths return an empty list (no NRE)
- **Remove**: path indexes remove a single item; no index still removes all matches
- **Parser**: exceptions include line numbers; removed unused `TokenType` / `RootToken`

## Tests

48 xUnit tests covering create/builder, load/parse, path API, update/remove, serialization order/round-trip, and error edges.

`dotnet build -c Release` and `dotnet test -c Release` pass locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2fa163-02aa-4310-be53-d0f5b4e2a6e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2fa163-02aa-4310-be53-d0f5b4e2a6e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

