### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a single **.NET / C# class library** — `NginxConfigParser` (parses/builds/writes nginx config files). There are no servers, databases, or web/UI services to run; correctness is verified via the xUnit test suite. Standard commands live in `README.md` and `.github/workflows/build.yml`.
+
+### Toolchain
+- Requires the **.NET 10 SDK** (the library multi-targets `netstandard2.0;netstandard2.1;net9.0;net10.0`; test/console projects target `net10.0`).
+- The SDK is installed at `~/.dotnet` and added to `PATH`/`DOTNET_ROOT` via `~/.bashrc`, so `dotnet` is available in interactive shells. If a non-interactive shell can't find it, either source `~/.bashrc` or call the full path `~/.dotnet/dotnet`.
+
+### Projects
+- `NginxConfigParser/` — the core library.
+- `NginxConfigParserUnitTests/` — the authoritative xUnit test suite (`dotnet test`).
+- `NginxConfigParserTests/` — a manual console demo/smoke-test harness (not a real test project).
+
+### Build / test (CI-gated, see `.github/workflows/build.yml`)
+```bash
+dotnet restore
+dotnet build --no-restore -c Release
+dotnet test --no-build -c Release --verbosity normal
+```
+
+### Running the console demo
+`dotnet run --project NginxConfigParserTests` reads `test.conf` using a path relative to the **current working directory**, so run it from inside `NginxConfigParserTests/` (or a directory containing `test.conf`). Running from the repo root throws `FileNotFoundException: test.conf`. The demo writes `temp.conf`/`temp2.conf` into the working directory — these are throwaway artifacts and should not be committed.
+
+### Lint / formatting
+- There is no dedicated linter; style is governed by the root `.editorconfig`. Use `dotnet format` (`--verify-no-changes` to check).
+- `dotnet format` is **not** run in CI; only restore/build/test are gated. `dotnet format --verify-no-changes` currently reports pre-existing style deviations (line-ending/charset) in some test files, so do not treat a non-zero format exit as a build/test failure.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this repo (the `NginxConfigParser` .NET class library) and documents durable, non-obvious guidance for future cloud agents in a new `AGENTS.md`.

This repo is a single .NET/C# library with an xUnit test suite and a console demo harness — there are no servers, databases, or UI services to run.

## Environment setup performed
- Installed the **.NET 10 SDK** (`10.0.302`) to `~/.dotnet` (added to `PATH`/`DOTNET_ROOT` via `~/.bashrc`).
- Configured the update script to install the SDK (idempotent) and run `dotnet restore`.

## Verification
- `dotnet restore` — OK
- `dotnet build --no-restore -c Release` — 0 errors
- `dotnet test --no-build -c Release` — **48/48 passed**
- `dotnet run --project NginxConfigParserTests` (from the project dir) — creates `temp2.conf`, loads/parses `test.conf`, reads/updates/adds tokens, saves. Works end-to-end.

## Notes
- `dotnet format` is available for linting but is **not** CI-gated (CI runs restore/build/test only). It currently reports pre-existing style deviations (line-ending/charset) in some test files; left untouched as out of scope for environment setup.
- No application code was modified.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad2a6044-1fcf-4261-ab60-a8a4ed0cdb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad2a6044-1fcf-4261-ab60-a8a4ed0cdb47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

